### PR TITLE
be able to retrieve the current Yap configuration

### DIFF
--- a/lib/yap.rb
+++ b/lib/yap.rb
@@ -34,6 +34,10 @@ module Yap
     yield(DEFAULTS)
   end
 
+  def self.configuration
+    DEFAULTS.dup
+  end
+
   included do
     extend ColumnMapper
 

--- a/test/test_yap.rb
+++ b/test/test_yap.rb
@@ -5,6 +5,22 @@ class TestYap < ActiveSupport::TestCase
     @saved_defaults = Yap::DEFAULTS.dup
   end
 
+  def test_configuration
+    Yap.configure do |d|
+      d.page = 2
+      d.per_page = 7
+      d.sort = :name
+    end
+
+    conf = Yap.configuration
+
+    assert_equal 2, conf.page
+    assert_equal 7, conf.per_page
+    assert_equal :name, conf.sort
+
+    restore_defaults
+  end
+
   def test_default_parameters
     page = User.paginate
 


### PR DESCRIPTION
With this change it will be possible to get the current Yap settings via Yap.configuration instead of fiddling around with Yap::DEFAULTS
